### PR TITLE
Make nested ToC list

### DIFF
--- a/lib/page-toc-filter.rb
+++ b/lib/page-toc-filter.rb
@@ -29,18 +29,18 @@ class PageTocFilter < HTML::Pipeline::Filter
       link = %(<a href="##{id}" id="markdown-toc-#{id}">#{text}</a>)
 
       if last_level.nil?
-        toc << %(<li>\n#{link}\n)
+        toc << %(<li>#{link})
       elsif current_level == last_level
-        toc << %(</li><li>\n#{link}\n)
+        toc << %(</li>\n<li>#{link})
       elsif current_level > last_level
-        toc << %(<ul><li>#{link}\n)
+        toc << %(<ul><li>#{link})
       elsif current_level < last_level
-        toc << %(</li></ul><li>#{link}\n)
+        toc << %(</li></ul>\n<li>#{link})
       end
 
       last_level = current_level
     end
-    toc << %(</li></ul>)
+    toc << %(</li>\n</ul>)
     toc
   end
 end

--- a/lib/page-toc-filter.rb
+++ b/lib/page-toc-filter.rb
@@ -19,6 +19,7 @@ class PageTocFilter < HTML::Pipeline::Filter
 
     toc = %(<ul id="markdown-toc">\n)
     last_level = nil
+    depth = 1
 
     levels.each do |node|
       current_level = node.name.match(/h(\d)/)[1]
@@ -33,14 +34,16 @@ class PageTocFilter < HTML::Pipeline::Filter
       elsif current_level == last_level
         toc << %(</li>\n<li>#{link})
       elsif current_level > last_level
-        toc << %(<ul><li>#{link})
+        depth += 1
+        toc << %(\n<ul><li>#{link})
       elsif current_level < last_level
+        depth -= 1
         toc << %(</li></ul>\n<li>#{link})
       end
 
       last_level = current_level
     end
-    toc << %(</li>\n</ul>)
+    toc << %(</li>\n</ul>) * depth
     toc
   end
 end

--- a/test/fixtures/plain_toc.html
+++ b/test/fixtures/plain_toc.html
@@ -4,22 +4,22 @@
 </ul>
 
 <h1>
-<a id="header-level-1" class="anchor" href="#header-level-1" aria-hidden="true"><span class="octicon octicon-link"></span></a>Header level 1</h1>
+<a id="header-level-1" class="anchor" href="#header-level-1" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Header level 1</h1>
 
 <h2>
-<a id="header-level-2" class="anchor" href="#header-level-2" aria-hidden="true"><span class="octicon octicon-link"></span></a>Header level 2</h2>
+<a id="header-level-2" class="anchor" href="#header-level-2" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Header level 2</h2>
 
 <h3>
-<a id="header-level-3" class="anchor" href="#header-level-3" aria-hidden="true"><span class="octicon octicon-link"></span></a>Header level 3</h3>
+<a id="header-level-3" class="anchor" href="#header-level-3" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Header level 3</h3>
 
 <h4>
-<a id="header-level-4" class="anchor" href="#header-level-4" aria-hidden="true"><span class="octicon octicon-link"></span></a>Header level 4</h4>
+<a id="header-level-4" class="anchor" href="#header-level-4" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Header level 4</h4>
 
 <h1>
-<a id="other-header-level-1" class="anchor" href="#other-header-level-1" aria-hidden="true"><span class="octicon octicon-link"></span></a>Other header level 1</h1>
+<a id="other-header-level-1" class="anchor" href="#other-header-level-1" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Other header level 1</h1>
 
 <h2>
-<a id="other-header-level-2" class="anchor" href="#other-header-level-2" aria-hidden="true"><span class="octicon octicon-link"></span></a>Other header level 2</h2>
+<a id="other-header-level-2" class="anchor" href="#other-header-level-2" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Other header level 2</h2>
 
 <h3>
-<a id="other-header-level-3" class="anchor" href="#other-header-level-3" aria-hidden="true"><span class="octicon octicon-link"></span></a>Other header level 3</h3>
+<a id="other-header-level-3" class="anchor" href="#other-header-level-3" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Other header level 3</h3>

--- a/test/fixtures/toc_levels.html
+++ b/test/fixtures/toc_levels.html
@@ -1,8 +1,14 @@
 <ul id="markdown-toc">
-<li><a href="#header--level-2" id="markdown-toc-header--level-2">Header \` level 2</a></li>
-<li><a href="#header-level-3" id="markdown-toc-header-level-3">Header level 3</a></li>
-<li><a href="#other-header-level-2" id="markdown-toc-other-header-level-2">Other header level 2</a></li>
+<li>
+<a href="#header--level-2" id="markdown-toc-header--level-2">Header \` level 2</a>
+<ul><li><a href="#header-level-3" id="markdown-toc-header-level-3">Header level 3</a></li></ul>
+</li>
+<li>
+<a href="#other-header-level-2" id="markdown-toc-other-header-level-2">Other header level 2</a>
+<ul>
 <li><a href="#other-header-level-3" id="markdown-toc-other-header-level-3">Other header level 3</a></li>
+</ul>
+</li>
 </ul>
 
 <h1>

--- a/test/fixtures/toc_levels.html
+++ b/test/fixtures/toc_levels.html
@@ -6,22 +6,22 @@
 </ul>
 
 <h1>
-<a id="header-level-1" class="anchor" href="#header-level-1" aria-hidden="true"><span class="octicon octicon-link"></span></a>Header level 1</h1>
+<a id="header-level-1" class="anchor" href="#header-level-1" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Header level 1</h1>
 
 <h2>
-<a id="header--level-2" class="anchor" href="#header--level-2" aria-hidden="true"><span class="octicon octicon-link"></span></a>Header \` level 2</h2>
+<a id="header--level-2" class="anchor" href="#header--level-2" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Header \` level 2</h2>
 
 <h3>
-<a id="header-level-3" class="anchor" href="#header-level-3" aria-hidden="true"><span class="octicon octicon-link"></span></a>Header level 3</h3>
+<a id="header-level-3" class="anchor" href="#header-level-3" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Header level 3</h3>
 
 <h4>
-<a id="header-level-4" class="anchor" href="#header-level-4" aria-hidden="true"><span class="octicon octicon-link"></span></a>Header level 4</h4>
+<a id="header-level-4" class="anchor" href="#header-level-4" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Header level 4</h4>
 
 <h1>
-<a id="other-header-level-1" class="anchor" href="#other-header-level-1" aria-hidden="true"><span class="octicon octicon-link"></span></a>Other header level 1</h1>
+<a id="other-header-level-1" class="anchor" href="#other-header-level-1" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Other header level 1</h1>
 
 <h2>
-<a id="other-header-level-2" class="anchor" href="#other-header-level-2" aria-hidden="true"><span class="octicon octicon-link"></span></a>Other header level 2</h2>
+<a id="other-header-level-2" class="anchor" href="#other-header-level-2" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Other header level 2</h2>
 
 <h3>
-<a id="other-header-level-3" class="anchor" href="#other-header-level-3" aria-hidden="true"><span class="octicon octicon-link"></span></a>Other header level 3</h3>
+<a id="other-header-level-3" class="anchor" href="#other-header-level-3" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Other header level 3</h3>


### PR DESCRIPTION
Given this text:

```markdown
## Hello
### World
## Hi
```

With `toc_levels: "h2, h3"`, `#page_toc_filter` generates:

```html
<ul>
  <li><a href..>Hello</a></li>
  <li><a href..>World</a></li>
  <li><a href..>Hi</a></li>
</ul>
```

[`result[:toc]`](https://github.com/jch/html-pipeline/blob/419436767dce642a03fa719cc1c75e23d174861b/lib/html/pipeline/toc_filter.rb#L50) from `TableOfContentsFilter` returns the same thing so isn't really useful here. This PR changes `#page_toc_filter` to  return a nested ToC:


```html
<ul>
  <li>
    <a href..>Hello</a>
    <ul><li><a href..>World</a></li></ul>
  </li>
  <li><a href..>Hi</a></li>
</ul>
```

:heart: Probably need some tests on this, I think especially for these cases:

1. tags are closed properly
2. skip levels work
3. something sensible happens when heading levels are skipped/incorrectly marked up, for example: 

   ```markdown
   #### Level 4
   ### Level 3
   # Level 1
   ```

cc @gjtorikian 